### PR TITLE
Extract prompt templates into shared module

### DIFF
--- a/ai_proposal_generator.py
+++ b/ai_proposal_generator.py
@@ -24,6 +24,10 @@ except ImportError:
 
 # Import the existing AI clients correctly
 from ai_clients import Claude37SonnetClient, DeepseekR1Client
+from prompts import (
+    RESEARCH_PROPOSAL_PROMPT_FOOTER,
+    RESEARCH_PROPOSAL_PROMPT_HEADER,
+)
 
 # Define the file order for processing
 FILE_ORDER = [
@@ -59,27 +63,9 @@ def get_project_title(doc_folder: Path) -> str:
 
 def prepare_prompt(file_contents: Dict[str, str], project_title: str) -> str:
     """Prepare the prompt for the AI model."""
-    prompt = f"""
-Create a formal academic research proposal for a project titled "{project_title}".
+    prompt = RESEARCH_PROPOSAL_PROMPT_HEADER.format(project_title=project_title)
+    prompt += "\n"
 
-Use the following content from previous design documents to create a comprehensive, well-structured academic research proposal. Format it according to standard academic conventions with proper sections, citations, and academic tone.
-
-The research proposal should include:
-1. Title Page
-2. Abstract
-3. Introduction and Problem Statement
-4. Literature Review
-5. Research Questions and Objectives
-6. Methodology and Technical Approach
-7. Implementation Plan and Timeline
-8. Expected Results and Impact
-9. Conclusion
-10. References
-
-Below are the source documents to synthesize into the proposal:
-
-"""
-    
     # Add each file's content to the prompt
     for file_name in FILE_ORDER:
         if file_name in file_contents:
@@ -88,12 +74,7 @@ Below are the source documents to synthesize into the proposal:
             prompt += file_contents[file_name]
             prompt += "\n\n"
 
-    prompt += """
-Create a cohesive, professionally formatted academic research proposal that integrates these materials. 
-Use formal academic language and structure. Ensure proper citation of external works where appropriate.
-Focus on presenting this as a serious, innovative research initiative with clear methodology and expected outcomes.
-The proposal should be comprehensive enough for submission to a major research funding organization.
-"""
+    prompt += RESEARCH_PROPOSAL_PROMPT_FOOTER
 
     return prompt
 

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -32,6 +32,25 @@ except ImportError:
     print("python-dotenv not installed. Environment variables must be set manually.")
 
 from ai_clients import AIOrchestrator
+from prompts import (
+    CLARIFICATION_QA_SYSTEM_PROMPT,
+    STEP_1_SYSTEM_PROMPT,
+    STEP_1_USER_PROMPT_TEMPLATE,
+    STEP_2_SYSTEM_PROMPT,
+    STEP_2_USER_PROMPT_TEMPLATE,
+    STEP_3_SYSTEM_PROMPT,
+    STEP_3_USER_PROMPT_TEMPLATE,
+    STEP_4_SYSTEM_PROMPT,
+    STEP_4_USER_PROMPT_TEMPLATE,
+    STEP_5_SYSTEM_PROMPT,
+    STEP_5_USER_PROMPT_TEMPLATE,
+    STEP_6_SYSTEM_PROMPT,
+    STEP_6_USER_PROMPT_TEMPLATE,
+    STEP_7_SYSTEM_PROMPT,
+    STEP_7_USER_PROMPT_TEMPLATE,
+    STEP_8_SYSTEM_PROMPT,
+    STEP_8_USER_PROMPT_TEMPLATE,
+)
 
 class ProjectFile:
     def __init__(self, path: str, content: str):
@@ -204,10 +223,7 @@ def main():
         conversation = [
             {
                 "role": "system",
-                "content": (
-                    "You are a helpful AI that clarifies the user's domain or challenge. "
-                    "Ask short follow-up questions to fully understand the user's needs."
-                )
+                "content": CLARIFICATION_QA_SYSTEM_PROMPT,
             },
             {"role": "user", "content": user_vision},
         ]
@@ -266,135 +282,43 @@ def main():
     STEPS = [
         {
             "phase_name": "1) Context & Constraints Clarification",
-            "system_prompt": (
-                "You are a specialized solutions architect. The user will describe a domain or challenge.\n"
-                "Step 1: Summarize the user's domain, goals, and constraints thoroughly. Then, confirm your understanding of them.\n"
-                "Additionally, collect any unusual references or lesser-known methods you can recall that might apply.\n"
-                "DO NOT disclaim feasibility. Provide a crisp summary of what the user wants, plus a short list of unique references from outside the mainstream."
-            ),
-            "user_prompt_template": (
-                "Step 1: Summarize my domain/goal and constraints. Also gather some obscure or cross-domain references that could help.\n"
-                "Keep it real and near-future, but do not disclaim feasibility. We want fresh synergy ideas.\n\n"
-                "Domain/Challenge:\n{vision}\n"
-            ),
+            "system_prompt": STEP_1_SYSTEM_PROMPT,
+            "user_prompt_template": STEP_1_USER_PROMPT_TEMPLATE,
         },
         {
             "phase_name": "2) Divergent Brainstorm of Solutions",
-            "system_prompt": (
-                "Step 2: Provide multiple new or radical solutions that incorporate the domain constraints and your cross-domain references.\n\n"
-                "Generate at least 5 distinct solutions.\n"
-                "Each solution must be novel, mixing known ideas in uncommon ways.\n"
-                "Avoid disclaimers like 'I'm only an AI' or 'This might not be feasible.' The user wants plausible near-future expansions.\n"
-                "Label them \"Solution A, B, C, etc.\""
-            ),
-            "user_prompt_template": (
-                "Step 2: Show me 5 or more novel synergy solutions for my stated domain.\n"
-                "Don't disclaim feasibility. Just produce creative combos.\n"
-                "Title each solution briefly, then describe it in a paragraph or two.\n\n"
-                "Domain/Challenge:\n{vision}\n\n"
-                "Context & Constraints (Step 1 Output):\n{step1}\n"
-            ),
+            "system_prompt": STEP_2_SYSTEM_PROMPT,
+            "user_prompt_template": STEP_2_USER_PROMPT_TEMPLATE,
         },
         {
             "phase_name": "3) Deep-Dive on Each Idea's Mechanism",
-            "system_prompt": (
-                "Step 3: For each proposed solution, deep-dive into how it might work. This includes:\n\n"
-                "Underlying logic or theoretical basis.\n"
-                "Potential synergy with domain constraints.\n"
-                "A short example scenario or test application.\n"
-                "A rough list of pros/cons.\n"
-                "No disclaimers or feasibility disclaimers—remain solution-focused."
-            ),
-            "user_prompt_template": (
-                "Step 3: For each solution A, B, C... do a deep-dive.\n"
-                "Show how it might actually function, how it ties back to the domain constraints, what example scenario it solves.\n"
-                "Keep the focus on actionable or near-future expansions—no disclaimers.\n\n"
-                "Domain/Challenge:\n{vision}\n\n"
-                "Context & Constraints (Step 1 Output):\n{step1}\n\n"
-                "Proposed Solutions (Step 2 Output):\n{step2}\n"
-            ),
+            "system_prompt": STEP_3_SYSTEM_PROMPT,
+            "user_prompt_template": STEP_3_USER_PROMPT_TEMPLATE,
         },
         {
             "phase_name": "4) Self-Critique for Gaps & Synergy",
-            "system_prompt": (
-                "Step 4: Critically review each solution for missing details, potential synergy across solutions, or expansions.\n\n"
-                "Identify any incomplete sub-points.\n"
-                "Suggest expansions or merges that might create an even stronger approach.\n"
-                "No disclaimers about the entire project's feasibility—just refine or unify solutions."
-            ),
-            "user_prompt_template": (
-                "Step 4: Critique your solutions from Step 3. Note where each is lacking detail, or which synergy merges solutions effectively.\n"
-                "Then propose 1–2 merged solutions that might be even stronger.\n\n"
-                "Domain/Challenge:\n{vision}\n\n"
-                "Context & Constraints (Step 1 Output):\n{step1}\n\n"
-                "Deep-Dive Solutions (Step 3 Output):\n{step3}\n"
-            ),
+            "system_prompt": STEP_4_SYSTEM_PROMPT,
+            "user_prompt_template": STEP_4_USER_PROMPT_TEMPLATE,
         },
         {
             "phase_name": "5) Merged Breakthrough Blueprint",
-            "system_prompt": (
-                "Step 5: Provide a final 'Merged Breakthrough Blueprint.' This blueprint is a synergy of the best or boldest features from the prior solutions, shaped into a coherent design.\n\n"
-                "Summarize the blueprint in 3–5 paragraphs, focusing on how it pushes beyond standard practice.\n"
-                "Emphasize real near-future expansions, not disclaimers.\n"
-                "Output the blueprint in `=== File: doc/BREAKTHROUGH_BLUEPRINT.md ===`"
-            ),
-            "user_prompt_template": (
-                "Step 5: Merge your best solutions into one cohesive blueprint.\n"
-                "Aim for truly new synergy beyond typical references.\n"
-                "Provide enough detail so I can see how it might be genuinely game-changing.\n"
-                "Place the blueprint in `=== File: doc/BREAKTHROUGH_BLUEPRINT.md ===`\n\n"
-                "Domain/Challenge:\n{vision}\n\n"
-                "Context & Constraints (Step 1 Output):\n{step1}\n\n"
-                "Critique & Synergy (Step 4 Output):\n{step4}\n"
-            ),
+            "system_prompt": STEP_5_SYSTEM_PROMPT,
+            "user_prompt_template": STEP_5_USER_PROMPT_TEMPLATE,
         },
         {
             "phase_name": "6) Implementation Path & Risk Minimization",
-            "system_prompt": (
-                "Step 6: Lay out an implementation or prototyping path. For each step, identify key resources needed.\n"
-                "No disclaimers about overall feasibility—just ways to mitigate risk or handle challenges.\n"
-                "Output the implementation path in `=== File: doc/IMPLEMENTATION_PATH.md ===`"
-            ),
-            "user_prompt_template": (
-                "Step 6: Give me a development path. List each milestone or partial prototype.\n"
-                "Show how I'd start small, prove key parts of the blueprint, then expand. No disclaimers needed; just solution-oriented steps.\n"
-                "Place the implementation path in `=== File: doc/IMPLEMENTATION_PATH.md ===`\n\n"
-                "Domain/Challenge:\n{vision}\n\n"
-                "Breakthrough Blueprint (Step 5 Output):\n{step5}\n"
-            ),
+            "system_prompt": STEP_6_SYSTEM_PROMPT,
+            "user_prompt_template": STEP_6_USER_PROMPT_TEMPLATE,
         },
         {
             "phase_name": "7) Cross-Checking with Prior Knowledge",
-            "system_prompt": (
-                "Step 7: Attempt to cross-check if any known open-source or industrial projects come close to your blueprint, and highlight differences.\n\n"
-                "If no direct references exist, you can say it's presumably novel.\n"
-                "Avoid disclaimers; remain solution-based.\n"
-                "Output the cross-check in `=== File: doc/NOVELTY_CHECK.md ===`"
-            ),
-            "user_prompt_template": (
-                "Step 7: Compare your blueprint with existing known projects. Are there partial overlaps? If so, how is this blueprint more advanced or new?\n"
-                "If none are close, then we label it as presumably novel. No disclaimers beyond that.\n"
-                "Place the cross-check in `=== File: doc/NOVELTY_CHECK.md ===`\n\n"
-                "Domain/Challenge:\n{vision}\n\n"
-                "Breakthrough Blueprint (Step 5 Output):\n{step5}\n\n"
-                "Implementation Path (Step 6 Output):\n{step6}\n"
-            ),
+            "system_prompt": STEP_7_SYSTEM_PROMPT,
+            "user_prompt_template": STEP_7_USER_PROMPT_TEMPLATE,
         },
         {
             "phase_name": "8) Q&A or Additional Elaborations",
-            "system_prompt": (
-                "Step 8: The user may have specific follow-up questions. Provide direct expansions or clarifications, always focusing on near-future feasibility. Refrain from disclaimers. Always produce constructive expansions.\n"
-                "Output any elaborations in `=== File: doc/ELABORATIONS.md ===`"
-            ),
-            "user_prompt_template": (
-                "Step 8: Let me ask any final clarifications about your final blueprint. Please keep it real near-future, no disclaimers.\n"
-                "Place any elaborations in `=== File: doc/ELABORATIONS.md ===`\n\n"
-                "Domain/Challenge:\n{vision}\n\n"
-                "Breakthrough Blueprint (Step 5 Output):\n{step5}\n\n"
-                "Implementation Path (Step 6 Output):\n{step6}\n\n"
-                "Novelty Check (Step 7 Output):\n{step7}\n\n"
-                "Let me know what aspects you'd like me to elaborate on or explain further."
-            ),
+            "system_prompt": STEP_8_SYSTEM_PROMPT,
+            "user_prompt_template": STEP_8_USER_PROMPT_TEMPLATE,
         },
     ]
 

--- a/prompts.py
+++ b/prompts.py
@@ -1,0 +1,175 @@
+CLARIFICATION_QA_SYSTEM_PROMPT = """You are a helpful AI that clarifies the user's domain or challenge.
+Ask short follow-up questions to fully understand the user's needs."""
+
+STEP_1_SYSTEM_PROMPT = """You are a specialized solutions architect. The user will describe a domain or challenge.
+Step 1: Summarize the user's domain, goals, and constraints thoroughly. Then, confirm your understanding of them.
+Additionally, collect any unusual references or lesser-known methods you can recall that might apply.
+DO NOT disclaim feasibility. Provide a crisp summary of what the user wants, plus a short list of unique references from outside the mainstream."""
+
+STEP_1_USER_PROMPT_TEMPLATE = """Step 1: Summarize my domain/goal and constraints. Also gather some obscure or cross-domain references that could help.
+Keep it real and near-future, but do not disclaim feasibility. We want fresh synergy ideas.
+
+Domain/Challenge:
+{vision}
+"""
+
+STEP_2_SYSTEM_PROMPT = """Step 2: Provide multiple new or radical solutions that incorporate the domain constraints and your cross-domain references.
+
+Generate at least 5 distinct solutions.
+Each solution must be novel, mixing known ideas in uncommon ways.
+Avoid disclaimers like 'I'm only an AI' or 'This might not be feasible.' The user wants plausible near-future expansions.
+Label them \"Solution A, B, C, etc.\""""
+
+STEP_2_USER_PROMPT_TEMPLATE = """Step 2: Show me 5 or more novel synergy solutions for my stated domain.
+Don't disclaim feasibility. Just produce creative combos.
+Title each solution briefly, then describe it in a paragraph or two.
+
+Domain/Challenge:
+{vision}
+
+Context & Constraints (Step 1 Output):
+{step1}
+"""
+
+STEP_3_SYSTEM_PROMPT = """Step 3: For each proposed solution, deep-dive into how it might work. This includes:
+
+Underlying logic or theoretical basis.
+Potential synergy with domain constraints.
+A short example scenario or test application.
+A rough list of pros/cons.
+No disclaimers or feasibility disclaimers—remain solution-focused."""
+
+STEP_3_USER_PROMPT_TEMPLATE = """Step 3: For each solution A, B, C... do a deep-dive.
+Show how it might actually function, how it ties back to the domain constraints, what example scenario it solves.
+Keep the focus on actionable or near-future expansions—no disclaimers.
+
+Domain/Challenge:
+{vision}
+
+Context & Constraints (Step 1 Output):
+{step1}
+
+Proposed Solutions (Step 2 Output):
+{step2}
+"""
+
+STEP_4_SYSTEM_PROMPT = """Step 4: Critically review each solution for missing details, potential synergy across solutions, or expansions.
+
+Identify any incomplete sub-points.
+Suggest expansions or merges that might create an even stronger approach.
+No disclaimers about the entire project's feasibility—just refine or unify solutions."""
+
+STEP_4_USER_PROMPT_TEMPLATE = """Step 4: Critique your solutions from Step 3. Note where each is lacking detail, or which synergy merges solutions effectively.
+Then propose 1–2 merged solutions that might be even stronger.
+
+Domain/Challenge:
+{vision}
+
+Context & Constraints (Step 1 Output):
+{step1}
+
+Deep-Dive Solutions (Step 3 Output):
+{step3}
+"""
+
+STEP_5_SYSTEM_PROMPT = """Step 5: Provide a final 'Merged Breakthrough Blueprint.' This blueprint is a synergy of the best or boldest features from the prior solutions, shaped into a coherent design.
+
+Summarize the blueprint in 3–5 paragraphs, focusing on how it pushes beyond standard practice.
+Emphasize real near-future expansions, not disclaimers.
+Output the blueprint in `=== File: doc/BREAKTHROUGH_BLUEPRINT.md ===`"""
+
+STEP_5_USER_PROMPT_TEMPLATE = """Step 5: Merge your best solutions into one cohesive blueprint.
+Aim for truly new synergy beyond typical references.
+Provide enough detail so I can see how it might be genuinely game-changing.
+Place the blueprint in `=== File: doc/BREAKTHROUGH_BLUEPRINT.md ===`
+
+Domain/Challenge:
+{vision}
+
+Context & Constraints (Step 1 Output):
+{step1}
+
+Critique & Synergy (Step 4 Output):
+{step4}
+"""
+
+STEP_6_SYSTEM_PROMPT = """Step 6: Lay out an implementation or prototyping path. For each step, identify key resources needed.
+No disclaimers about overall feasibility—just ways to mitigate risk or handle challenges.
+Output the implementation path in `=== File: doc/IMPLEMENTATION_PATH.md ===`"""
+
+STEP_6_USER_PROMPT_TEMPLATE = """Step 6: Give me a development path. List each milestone or partial prototype.
+Show how I'd start small, prove key parts of the blueprint, then expand. No disclaimers needed; just solution-oriented steps.
+Place the implementation path in `=== File: doc/IMPLEMENTATION_PATH.md ===`
+
+Domain/Challenge:
+{vision}
+
+Breakthrough Blueprint (Step 5 Output):
+{step5}
+"""
+
+STEP_7_SYSTEM_PROMPT = """Step 7: Attempt to cross-check if any known open-source or industrial projects come close to your blueprint, and highlight differences.
+
+If no direct references exist, you can say it's presumably novel.
+Avoid disclaimers; remain solution-based.
+Output the cross-check in `=== File: doc/NOVELTY_CHECK.md ===`"""
+
+STEP_7_USER_PROMPT_TEMPLATE = """Step 7: Compare your blueprint with existing known projects. Are there partial overlaps? If so, how is this blueprint more advanced or new?
+If none are close, then we label it as presumably novel. No disclaimers beyond that.
+Place the cross-check in `=== File: doc/NOVELTY_CHECK.md ===`
+
+Domain/Challenge:
+{vision}
+
+Breakthrough Blueprint (Step 5 Output):
+{step5}
+
+Implementation Path (Step 6 Output):
+{step6}
+"""
+
+STEP_8_SYSTEM_PROMPT = """Step 8: The user may have specific follow-up questions. Provide direct expansions or clarifications, always focusing on near-future feasibility. Refrain from disclaimers. Always produce constructive expansions.
+Output any elaborations in `=== File: doc/ELABORATIONS.md ===`"""
+
+STEP_8_USER_PROMPT_TEMPLATE = """Step 8: Let me ask any final clarifications about your final blueprint. Please keep it real near-future, no disclaimers.
+Place any elaborations in `=== File: doc/ELABORATIONS.md ===`
+
+Domain/Challenge:
+{vision}
+
+Breakthrough Blueprint (Step 5 Output):
+{step5}
+
+Implementation Path (Step 6 Output):
+{step6}
+
+Novelty Check (Step 7 Output):
+{step7}
+
+Let me know what aspects you'd like me to elaborate on or explain further.
+"""
+
+RESEARCH_PROPOSAL_PROMPT_HEADER = """Create a formal academic research proposal for a project titled "{project_title}".
+
+Use the following content from previous design documents to create a comprehensive, well-structured academic research proposal.
+Format it according to standard academic conventions with proper sections, citations, and academic tone.
+
+The research proposal should include:
+1. Title Page
+2. Abstract
+3. Introduction and Problem Statement
+4. Literature Review
+5. Research Questions and Objectives
+6. Methodology and Technical Approach
+7. Implementation Plan and Timeline
+8. Expected Results and Impact
+9. Conclusion
+10. References
+
+Below are the source documents to synthesize into the proposal:
+"""
+
+RESEARCH_PROPOSAL_PROMPT_FOOTER = """Create a cohesive, professionally formatted academic research proposal that integrates these materials.
+Use formal academic language and structure. Ensure proper citation of external works where appropriate.
+Focus on presenting this as a serious, innovative research initiative with clear methodology and expected outcomes.
+The proposal should be comprehensive enough for submission to a major research funding organization."""


### PR DESCRIPTION
## Summary
- collect all orchestrator and proposal generator prompt text into a new `prompts.py` constants module
- update the orchestrator to reference the shared prompt strings for conversation setup and each framework step
- reuse the shared research proposal prompt header and footer inside `ai_proposal_generator.prepare_prompt`

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68dc1480d6f4832693fb7a6aa15bc0c7